### PR TITLE
Throw on error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glacierjs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A framework agnostic typed data store for client side applications.",
   "main": "./index.js",
   "typings": "./index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ const applyMiddleware = async <T>(state: T, action: Action<T>, middleware: Glaci
       let res = m.onError(state, finalState, action, err);
       if (res) await res;
     }
-    return state;
+    throw err;
   }
 };
 


### PR DESCRIPTION
If an error happens during the dispatch, the middleware should throw an error. At the moment it returns the previous state.